### PR TITLE
feat: #84474 - Workorder description

### DIFF
--- a/src/pages/Entity/WorkOrderInfo.tsx
+++ b/src/pages/Entity/WorkOrderInfo.tsx
@@ -59,11 +59,13 @@ const WorkOrderInfo = ({
                 }
             >
                 <TagInfoWrapper>
-                    <CollapsibleCard cardTitle="Description">
-                        <Description>
-                            {removeHtmlFromText(workOrder?.description)}
-                        </Description>
-                    </CollapsibleCard>
+                    {workOrder?.description && (
+                        <CollapsibleCard cardTitle="Description">
+                            <Description>
+                                {removeHtmlFromText(workOrder?.description)}
+                            </Description>
+                        </CollapsibleCard>
+                    )}
                     <h5>Attachments</h5>
                     <Attachments
                         getAttachments={(

--- a/src/pages/Entity/WorkOrderInfo.tsx
+++ b/src/pages/Entity/WorkOrderInfo.tsx
@@ -63,7 +63,7 @@ const WorkOrderInfo = ({
                         <Description>
                             {workOrder?.description
                                 ? removeHtmlFromText(workOrder?.description)
-                                : 'There is no description present, for more information see the short description.'}
+                                : 'A long description is not present, See the short description at the top of the page for all information available.'}
                         </Description>
                     </CollapsibleCard>
 

--- a/src/pages/Entity/WorkOrderInfo.tsx
+++ b/src/pages/Entity/WorkOrderInfo.tsx
@@ -3,7 +3,7 @@ import {
     Attachments,
     CollapsibleCard,
     ErrorPage,
-    HomeButton,
+    HomeButton
 } from '@equinor/procosys-webapp-components';
 import { CancelToken } from 'axios';
 import React from 'react';
@@ -16,7 +16,7 @@ import {
     McPkgPreview,
     PoPreview,
     Tag,
-    WoPreview,
+    WoPreview
 } from '../../services/apiTypes';
 import { removeHtmlFromText } from '../../utils/removeHtmlFromText';
 import removeSubdirectories from '../../utils/removeSubdirectories';
@@ -59,13 +59,14 @@ const WorkOrderInfo = ({
                 }
             >
                 <TagInfoWrapper>
-                    {workOrder?.description && (
-                        <CollapsibleCard cardTitle="Description">
-                            <Description>
-                                {removeHtmlFromText(workOrder?.description)}
-                            </Description>
-                        </CollapsibleCard>
-                    )}
+                    <CollapsibleCard cardTitle="Description">
+                        <Description>
+                            {workOrder?.description
+                                ? removeHtmlFromText(workOrder?.description)
+                                : 'There is no description present, for more information see the short description.'}
+                        </Description>
+                    </CollapsibleCard>
+
                     <h5>Attachments</h5>
                     <Attachments
                         getAttachments={(

--- a/src/pages/Entity/WorkOrderInfo.tsx
+++ b/src/pages/Entity/WorkOrderInfo.tsx
@@ -18,6 +18,7 @@ import {
     Tag,
     WoPreview,
 } from '../../services/apiTypes';
+import { removeHtmlFromText } from '../../utils/removeHtmlFromText';
 import removeSubdirectories from '../../utils/removeSubdirectories';
 import useCommonHooks from '../../utils/useCommonHooks';
 import useSnackbar from '../../utils/useSnackbar';
@@ -29,6 +30,10 @@ const TagInfoWrapper = styled.main`
         word-break: break-word;
         margin: 0;
     }
+`;
+
+const Description = styled.p`
+    white-space: pre-line;
 `;
 
 type WorkOrderInfoProps = {
@@ -55,7 +60,9 @@ const WorkOrderInfo = ({
             >
                 <TagInfoWrapper>
                     <CollapsibleCard cardTitle="Description">
-                        <p>{workOrder?.description}</p>
+                        <Description>
+                            {removeHtmlFromText(workOrder?.description)}
+                        </Description>
                     </CollapsibleCard>
                     <h5>Attachments</h5>
                     <Attachments

--- a/src/pages/Entity/WorkOrderInfo.tsx
+++ b/src/pages/Entity/WorkOrderInfo.tsx
@@ -3,7 +3,7 @@ import {
     Attachments,
     CollapsibleCard,
     ErrorPage,
-    HomeButton
+    HomeButton,
 } from '@equinor/procosys-webapp-components';
 import { CancelToken } from 'axios';
 import React from 'react';
@@ -16,7 +16,7 @@ import {
     McPkgPreview,
     PoPreview,
     Tag,
-    WoPreview
+    WoPreview,
 } from '../../services/apiTypes';
 import { removeHtmlFromText } from '../../utils/removeHtmlFromText';
 import removeSubdirectories from '../../utils/removeSubdirectories';

--- a/src/utils/removeHtmlFromText.test.ts
+++ b/src/utils/removeHtmlFromText.test.ts
@@ -1,0 +1,19 @@
+import { removeHtmlFromText } from './removeHtmlFromText';
+
+describe('Function removeHtmlFromText', () => {
+    const test1 = 'Hello World\n';
+    const test2 = 'Hello World';
+    const test3 = ' Hello World';
+
+    it('Should remove any html tags form string', () => {
+        const result = removeHtmlFromText('<p>Hello World</p>');
+        expect(result).toEqual(test1);
+        expect(result).not.toEqual(test2);
+        expect(result).not.toEqual(test3);
+    });
+    it('Should remove any html tags form string and keep white spaces', () => {
+        const result = removeHtmlFromText('Hello<p>World</p>');
+        expect(result).toEqual(test1);
+        expect(result).not.toEqual(test2);
+    });
+});

--- a/src/utils/removeHtmlFromText.ts
+++ b/src/utils/removeHtmlFromText.ts
@@ -1,26 +1,7 @@
 export function removeHtmlFromText(text?: string): string {
-    if (text) {
-        return text
-            .replace(/<\/P>/g, '\n')
-            .replace(/<P>/g, '')
-            .replace(/<\/a>/g, '\n')
-            .replace(/<a>/g, '')
-            .replace(/<\/div>/g, '\n')
-            .replace(/<div>/g, '')
-            .replace(/<\/span>/g, '\n')
-            .replace(/<span>/g, '')
-            .replace(/<\/h1>/g, '\n')
-            .replace(/<h1>/g, '')
-            .replace(/<\/h2>/g, '\n')
-            .replace(/<h2>/g, '')
-            .replace(/<\/h3>/g, '\n')
-            .replace(/<h3>/g, '')
-            .replace(/<\/h4>/g, '\n')
-            .replace(/<h4>/g, '')
-            .replace(/<\/h6>/g, '\n')
-            .replace(/<h6>/g, '')
-            .replace(/<\/h6>/g, '\n')
-            .replace(/<h6>/g, '');
-    }
-    return '';
+    if (!text) return '';
+    return text
+        .replace(/<\/[^]>/gm, '\n')
+        .replace(/<[^>]>/g, ' ')
+        .trimStart();
 }

--- a/src/utils/removeHtmlFromText.ts
+++ b/src/utils/removeHtmlFromText.ts
@@ -1,0 +1,26 @@
+export function removeHtmlFromText(text?: string): string {
+    if (text) {
+        return text
+            .replace(/<\/P>/g, '\n')
+            .replace(/<P>/g, '')
+            .replace(/<\/a>/g, '\n')
+            .replace(/<a>/g, '')
+            .replace(/<\/div>/g, '\n')
+            .replace(/<div>/g, '')
+            .replace(/<\/span>/g, '\n')
+            .replace(/<span>/g, '')
+            .replace(/<\/h1>/g, '\n')
+            .replace(/<h1>/g, '')
+            .replace(/<\/h2>/g, '\n')
+            .replace(/<h2>/g, '')
+            .replace(/<\/h3>/g, '\n')
+            .replace(/<h3>/g, '')
+            .replace(/<\/h4>/g, '\n')
+            .replace(/<h4>/g, '')
+            .replace(/<\/h6>/g, '\n')
+            .replace(/<h6>/g, '')
+            .replace(/<\/h6>/g, '\n')
+            .replace(/<h6>/g, '');
+    }
+    return '';
+}


### PR DESCRIPTION
[AB#84474](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/84474)

# Description
Added a function for removing all types of HTML tags, the function will add linebreaks and format text.

![image](https://user-images.githubusercontent.com/28740201/132564201-0f9a3b89-a15b-445b-a182-79d95775871f.png)

Also removed description dropdown box if no description is present. See image from Carlsberg WO

![image](https://user-images.githubusercontent.com/28740201/132564399-dc908870-6fbb-4f0d-abd3-fdd2cc69d25e.png)


# Tests
Added unit test covering the removeHtmlFromText util function.