### PR TITLE
Bug/86184 users with read access cannot open/see a punch

### DIFF
--- a/src/pages/Checklist/NewPunch/NewPunch.tsx
+++ b/src/pages/Checklist/NewPunch/NewPunch.tsx
@@ -21,9 +21,10 @@ import styled from 'styled-components';
 import { COLORS } from '../../../style/GlobalStyles';
 
 export const AttachmentsWrapper = styled.div`
-    margin: 0 -4%;
+    margin: 0 -4% 16px -4%;
     padding: 16px 4%;
     background-color: ${COLORS.fadedBlue};
+    height: 100px;
 `;
 
 export type ChosenPerson = {

--- a/src/pages/Checklist/NewPunch/NewPunchForm.tsx
+++ b/src/pages/Checklist/NewPunch/NewPunchForm.tsx
@@ -28,13 +28,10 @@ export const NewPunchFormWrapper = styled.form`
     }
 `;
 
-export const FormButton = styled(Button)`
-    float: right;
+export const FormButtonWrapper = styled.div`
+    display: flex;
     margin: 16px 0;
-    & :disabled {
-        float: right;
-        margin: 16px 0;
-    }
+    justify-content: flex-end;
 `;
 
 export const DateField = styled.div`
@@ -52,6 +49,10 @@ export const DateField = styled.div`
     & > input:focus-visible {
         outline: 2px solid ${COLORS.mossGreen};
         box-shadow: none;
+    }
+    & > input:disabled {
+        box-shadow: none;
+        color: ${COLORS.disabledText};
     }
 `;
 
@@ -270,12 +271,14 @@ const NewPunchForm = ({
                     disabled={submitPunchStatus === AsyncStatus.LOADING}
                 />
                 {children}
-                <FormButton
-                    type="submit"
-                    disabled={submitPunchStatus === AsyncStatus.LOADING}
-                >
-                    {buttonText}
-                </FormButton>
+                <FormButtonWrapper>
+                    <Button
+                        type="submit"
+                        disabled={submitPunchStatus === AsyncStatus.LOADING}
+                    >
+                        {buttonText}
+                    </Button>
+                </FormButtonWrapper>
             </NewPunchFormWrapper>
         </>
     );

--- a/src/pages/Punch/ClearPunch/ClearPunch.test.tsx
+++ b/src/pages/Punch/ClearPunch/ClearPunch.test.tsx
@@ -14,6 +14,8 @@ describe('<ClearPunch/>', () => {
                     <ClearPunch
                         punchItem={testPunchItemUncleared}
                         setPunchItem={jest.fn()}
+                        canEdit={true}
+                        canClear={true}
                     />
                 ),
             })

--- a/src/pages/Punch/ClearPunch/ClearPunch.tsx
+++ b/src/pages/Punch/ClearPunch/ClearPunch.tsx
@@ -1,9 +1,14 @@
-import { Label, NativeSelect, TextField } from '@equinor/eds-core-react';
+import {
+    Button,
+    Label,
+    NativeSelect,
+    TextField,
+} from '@equinor/eds-core-react';
 import React from 'react';
 import { AsyncStatus } from '../../../contexts/McAppContext';
 import {
     DateField,
-    FormButton,
+    FormButtonWrapper,
     NewPunchFormWrapper,
 } from '../../Checklist/NewPunch/NewPunchForm';
 import useClearPunchFacade, {
@@ -30,11 +35,15 @@ export const PunchWrapper = styled.main``;
 type ClearPunchProps = {
     punchItem: PunchItem;
     setPunchItem: React.Dispatch<React.SetStateAction<PunchItem>>;
+    canEdit: boolean;
+    canClear: boolean;
 };
 
 const ClearPunch = ({
     punchItem,
     setPunchItem,
+    canEdit,
+    canClear,
 }: ClearPunchProps): JSX.Element => {
     const {
         updatePunchStatus,
@@ -62,7 +71,7 @@ const ClearPunch = ({
         showPersonsSearch,
         setShowPersonsSearch,
     } = useClearPunchFacade(setPunchItem);
-    const { api, params, url } = useCommonHooks();
+    const { api, params } = useCommonHooks();
 
     let descriptionBeforeEntering = '';
     let estimateBeforeEntering: number | null = 0;
@@ -82,7 +91,10 @@ const ClearPunch = ({
                             required
                             id="PunchCategorySelect"
                             label="Punch category"
-                            disabled={clearPunchStatus === AsyncStatus.LOADING}
+                            disabled={
+                                clearPunchStatus === AsyncStatus.LOADING ||
+                                canEdit === false
+                            }
                             defaultValue={
                                 ensure(
                                     categories.find(
@@ -108,7 +120,10 @@ const ClearPunch = ({
                             multiline
                             rows={5}
                             id="NewPunchDescription"
-                            disabled={clearPunchStatus === AsyncStatus.LOADING}
+                            disabled={
+                                clearPunchStatus === AsyncStatus.LOADING ||
+                                canEdit === false
+                            }
                             onFocus={(): string =>
                                 (descriptionBeforeEntering =
                                     punchItem.description)
@@ -132,7 +147,10 @@ const ClearPunch = ({
                             required
                             label="Raised by"
                             id="RaisedBySelect"
-                            disabled={clearPunchStatus === AsyncStatus.LOADING}
+                            disabled={
+                                clearPunchStatus === AsyncStatus.LOADING ||
+                                canEdit === false
+                            }
                             defaultValue={
                                 ensure(
                                     organizations.find(
@@ -156,7 +174,10 @@ const ClearPunch = ({
                             required
                             id="ClearingBySelect"
                             label="Clearing by"
-                            disabled={clearPunchStatus === AsyncStatus.LOADING}
+                            disabled={
+                                clearPunchStatus === AsyncStatus.LOADING ||
+                                canEdit === false
+                            }
                             defaultValue={
                                 ensure(
                                     organizations.find(
@@ -186,8 +207,9 @@ const ClearPunch = ({
                                     : ''
                             }
                             readOnly
+                            disabled={canEdit === false}
                             inputIcon={
-                                punchItem.actionByPerson ? (
+                                punchItem.actionByPerson && canEdit ? (
                                     <div
                                         onClick={(): void =>
                                             handleActionByPersonChange(
@@ -213,6 +235,10 @@ const ClearPunch = ({
                                 type="date"
                                 id="DueDatePicker"
                                 role="datepicker"
+                                disabled={
+                                    clearPunchStatus === AsyncStatus.LOADING ||
+                                    canEdit === false
+                                }
                                 value={
                                     punchItem.dueDate
                                         ? punchItem.dueDate.split('T')[0]
@@ -234,7 +260,8 @@ const ClearPunch = ({
                             label="Type"
                             disabled={
                                 clearPunchStatus === AsyncStatus.LOADING ||
-                                types.length < 1
+                                types.length < 1 ||
+                                canEdit === false
                             }
                             defaultValue={
                                 punchItem.typeCode
@@ -259,7 +286,8 @@ const ClearPunch = ({
                             label="Sorting"
                             disabled={
                                 clearPunchStatus === AsyncStatus.LOADING ||
-                                sortings.length < 1
+                                sortings.length < 1 ||
+                                canEdit === false
                             }
                             defaultValue={
                                 punchItem.sorting
@@ -284,7 +312,8 @@ const ClearPunch = ({
                             label="Priority"
                             disabled={
                                 clearPunchStatus === AsyncStatus.LOADING ||
-                                priorities.length < 1
+                                priorities.length < 1 ||
+                                canEdit === false
                             }
                             defaultValue={
                                 punchItem.priorityCode
@@ -312,7 +341,10 @@ const ClearPunch = ({
                             }
                             label="Estimate"
                             id="Estimate"
-                            disabled={clearPunchStatus === AsyncStatus.LOADING}
+                            disabled={
+                                clearPunchStatus === AsyncStatus.LOADING ||
+                                canEdit === false
+                            }
                             onFocus={(): number | null =>
                                 (estimateBeforeEntering = punchItem.estimate)
                             }
@@ -375,18 +407,21 @@ const ClearPunch = ({
                                     )
                                 }
                                 setSnackbarText={setSnackbarText}
-                                readOnly={false}
+                                readOnly={canEdit === false}
                             />
                         </AttachmentsWrapper>
-                        <FormButton
-                            type="submit"
-                            disabled={
-                                updatePunchStatus === AsyncStatus.LOADING ||
-                                clearPunchStatus === AsyncStatus.LOADING
-                            }
-                        >
-                            Clear
-                        </FormButton>
+                        <FormButtonWrapper>
+                            <Button
+                                type="submit"
+                                disabled={
+                                    updatePunchStatus === AsyncStatus.LOADING ||
+                                    clearPunchStatus === AsyncStatus.LOADING ||
+                                    canClear === false
+                                }
+                            >
+                                Clear
+                            </Button>
+                        </FormButtonWrapper>
                     </NewPunchFormWrapper>
                 </>
             );

--- a/src/pages/Punch/PunchPage.tsx
+++ b/src/pages/Punch/PunchPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import Axios from 'axios';
 import EdsIcon from '../../components/icons/EdsIcon';
@@ -22,6 +22,7 @@ import { DetailsWrapper } from '../Entity/EntityPage';
 import { DotProgress } from '@equinor/eds-core-react';
 import AsyncPage from '../../components/AsyncPage';
 import TagInfo from '../../components/TagInfo';
+import PlantContext from '../../contexts/PlantContext';
 
 const PunchPage = (): JSX.Element => {
     const { api, params, path, history, url } = useCommonHooks();
@@ -29,6 +30,7 @@ const PunchPage = (): JSX.Element => {
     const [fetchPunchStatus, setFetchPunchStatus] = useState<AsyncStatus>(
         AsyncStatus.LOADING
     );
+    const { permissions } = useContext(PlantContext);
 
     useEffect(() => {
         const source = Axios.CancelToken.source();
@@ -53,7 +55,11 @@ const PunchPage = (): JSX.Element => {
     const determineComponentToRender = (): JSX.Element => {
         if (punch != undefined) {
             return punch.clearedAt ? (
-                <VerifyPunch punchItem={punch} />
+                <VerifyPunch
+                    punchItem={punch}
+                    canUnclear={permissions.includes('PUNCHLISTITEM/CLEAR')}
+                    canVerify={permissions.includes('PUNCHLISTITEM/VERIFY')}
+                />
             ) : (
                 <ClearPunch
                     punchItem={punch}
@@ -62,6 +68,8 @@ const PunchPage = (): JSX.Element => {
                             React.SetStateAction<PunchItem>
                         >
                     }
+                    canEdit={permissions.includes('PUNCHLISTITEM/WRITE')}
+                    canClear={permissions.includes('PUNCHLISTITEM/CLEAR')}
                 />
             );
         }
@@ -100,7 +108,7 @@ const PunchPage = (): JSX.Element => {
     };
 
     return (
-        <>
+        <main>
             <Navbar
                 noBorder
                 leftContent={
@@ -149,14 +157,8 @@ const PunchPage = (): JSX.Element => {
                     label={'Tag info'}
                 />
             </NavigationFooter>
-        </>
+        </main>
     );
 };
 
-export default withAccessControl(PunchPage, [
-    'PUNCHLISTITEM/READ',
-    'PUNCHLISTITEM/WRITE',
-    'PUNCHLISTITEM/CLEAR',
-    'PUNCHLISTITEM/VERIFY',
-    'TAG/READ',
-]);
+export default withAccessControl(PunchPage, ['PUNCHLISTITEM/READ', 'TAG/READ']);

--- a/src/pages/Punch/PunchPage.tsx
+++ b/src/pages/Punch/PunchPage.tsx
@@ -53,14 +53,17 @@ const PunchPage = (): JSX.Element => {
     }, [api, params]);
 
     const determineComponentToRender = (): JSX.Element => {
-        if (punch != undefined) {
-            return punch.clearedAt ? (
+        if (punch === undefined) return <SkeletonLoadingPage />;
+        if (punch.clearedAt != null) {
+            return (
                 <VerifyPunch
                     punchItem={punch}
                     canUnclear={permissions.includes('PUNCHLISTITEM/CLEAR')}
                     canVerify={permissions.includes('PUNCHLISTITEM/VERIFY')}
                 />
-            ) : (
+            );
+        } else {
+            return (
                 <ClearPunch
                     punchItem={punch}
                     setPunchItem={
@@ -73,7 +76,6 @@ const PunchPage = (): JSX.Element => {
                 />
             );
         }
-        return <SkeletonLoadingPage />;
     };
 
     const determineDetailsCard = (): JSX.Element => {

--- a/src/pages/Punch/VerifyPunch/VerifyPunch.tsx
+++ b/src/pages/Punch/VerifyPunch/VerifyPunch.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@equinor/eds-core-react';
 import { CancelToken } from 'axios';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { AsyncStatus } from '../../../contexts/McAppContext';
 import { Attachment, PunchItem } from '../../../services/apiTypes';

--- a/src/pages/Punch/VerifyPunch/VerifyPunch.tsx
+++ b/src/pages/Punch/VerifyPunch/VerifyPunch.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@equinor/eds-core-react';
 import { CancelToken } from 'axios';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { AsyncStatus } from '../../../contexts/McAppContext';
 import { Attachment, PunchItem } from '../../../services/apiTypes';
@@ -10,7 +10,7 @@ import useSnackbar from '../../../utils/useSnackbar';
 import removeSubdirectories from '../../../utils/removeSubdirectories';
 import { Attachments } from '@equinor/procosys-webapp-components';
 
-const VerifyPunchWrapper = styled.main`
+const VerifyPunchWrapper = styled.div`
     padding: 16px 4% 78px 4%;
     & > p {
         margin-top: 0;
@@ -66,7 +66,10 @@ const VerifyPunch = ({
         if (punchItem.verifiedByFirstName) {
             return (
                 <Button
-                    disabled={punchActionStatus === AsyncStatus.LOADING}
+                    disabled={
+                        punchActionStatus === AsyncStatus.LOADING ||
+                        canVerify === false
+                    }
                     onClick={(): Promise<void> =>
                         handlePunchAction(PunchAction.UNVERIFY, () => {
                             history.push(url);
@@ -80,7 +83,10 @@ const VerifyPunch = ({
             return (
                 <>
                     <Button
-                        disabled={punchActionStatus === AsyncStatus.LOADING}
+                        disabled={
+                            punchActionStatus === AsyncStatus.LOADING ||
+                            canUnclear === false
+                        }
                         onClick={(): Promise<void> =>
                             handlePunchAction(PunchAction.UNCLEAR, () =>
                                 history.push(url)
@@ -90,7 +96,10 @@ const VerifyPunch = ({
                         Unclear
                     </Button>
                     <Button
-                        disabled={punchActionStatus === AsyncStatus.LOADING}
+                        disabled={
+                            punchActionStatus === AsyncStatus.LOADING ||
+                            canVerify === false
+                        }
                         onClick={(): Promise<void> =>
                             handlePunchAction(PunchAction.REJECT, () =>
                                 history.push(
@@ -103,7 +112,10 @@ const VerifyPunch = ({
                     </Button>
 
                     <Button
-                        disabled={punchActionStatus === AsyncStatus.LOADING}
+                        disabled={
+                            punchActionStatus === AsyncStatus.LOADING ||
+                            canVerify === false
+                        }
                         onClick={(): Promise<void> =>
                             handlePunchAction(PunchAction.VERIFY, () => {
                                 history.push(
@@ -206,6 +218,7 @@ const VerifyPunch = ({
                 setSnackbarText={setSnackbarText}
             />
             <ButtonGroup>{determineButtonsToRender()}</ButtonGroup>
+            {snackbar}
         </VerifyPunchWrapper>
     );
 };

--- a/src/pages/Punch/VerifyPunch/VerifyPunch.tsx
+++ b/src/pages/Punch/VerifyPunch/VerifyPunch.tsx
@@ -29,9 +29,15 @@ const ButtonGroup = styled.div`
 
 type VerifyPunchProps = {
     punchItem: PunchItem;
+    canUnclear: boolean;
+    canVerify: boolean;
 };
 
-const VerifyPunch = ({ punchItem }: VerifyPunchProps): JSX.Element => {
+const VerifyPunch = ({
+    punchItem,
+    canUnclear,
+    canVerify,
+}: VerifyPunchProps): JSX.Element => {
     const { url, history, params, api } = useCommonHooks();
     const [punchActionStatus, setPunchActionStatus] = useState(
         AsyncStatus.INACTIVE

--- a/src/style/GlobalStyles.tsx
+++ b/src/style/GlobalStyles.tsx
@@ -18,6 +18,7 @@ export const COLORS = {
     workOrderIcon: '#990025',
     tagIcon: '#007079',
     purchaseOrderIcon: '#879199',
+    disabledText: tokens.colors.interactive.disabled__text.hex,
 };
 
 const GlobalStyles = createGlobalStyle`


### PR DESCRIPTION
Completes: [AB#86184](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/86184)

Users with read access can now open a punch, but cannot change anything. Users with clear access can clear & unclear, and users with verify access can verify, unverify and reject.

Also fixed a few small design issues on the ClearPunch and VerifyPunch pages.