### PR TITLE
Implemented service for comm with IPO-API.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
 import { SearchType } from './pages/Search/Search';
 import { AppConfig, FeatureFlags } from './services/appConfiguration';
 import { SavedSearchType } from './pages/Search/SavedSearches/SavedSearchResult';
+import { ProcosysIPOApiService } from './services/procosysIPOApi';
 
 export type McParams = {
     plant: string;
@@ -30,6 +31,7 @@ type AppProps = {
     appInsightsReactPlugin: ReactPlugin;
     appConfig: AppConfig;
     featureFlags: FeatureFlags;
+    procosysIPOApiInstance: ProcosysIPOApiService;
 };
 
 const App = ({
@@ -38,6 +40,7 @@ const App = ({
     appConfig,
     appInsightsReactPlugin: reactPlugin,
     featureFlags,
+    procosysIPOApiInstance,
 }: AppProps): JSX.Element => {
     return (
         <AppInsightsContext.Provider value={reactPlugin}>
@@ -46,6 +49,7 @@ const App = ({
                 auth={authInstance}
                 appConfig={appConfig}
                 featureFlags={featureFlags}
+                ipoApi={procosysIPOApiInstance}
             >
                 <Router basename={'/mc'}>
                     <ErrorBoundary>

--- a/src/components/error/ErrorBoundary.tsx
+++ b/src/components/error/ErrorBoundary.tsx
@@ -6,7 +6,7 @@ import {
 } from '@equinor/procosys-webapp-components';
 
 type ErrorProps = {
-    children: React.ReactChild;
+    children: JSX.Element;
 };
 
 type ErrorState = {
@@ -36,7 +36,7 @@ class ErrorBoundary extends React.Component<ErrorProps, ErrorState> {
         // console.error('ErrorInfo: ', errorInfo);
     }
 
-    render(): React.ReactChild {
+    render(): JSX.Element {
         if (this.state.hasError) {
             return (
                 <ErrorPage

--- a/src/contexts/McAppContext.tsx
+++ b/src/contexts/McAppContext.tsx
@@ -9,6 +9,7 @@ import { Plant } from '../services/apiTypes';
 import { AppConfig, FeatureFlags } from '../services/appConfiguration';
 import { IAuthService } from '../services/authService';
 import { ProcosysApiService } from '../services/procosysApi';
+import { ProcosysIPOApiService } from '../services/procosysIPOApi';
 
 type McAppContextProps = {
     availablePlants: Plant[];
@@ -17,6 +18,7 @@ type McAppContextProps = {
     auth: IAuthService;
     appConfig: AppConfig;
     featureFlags: FeatureFlags;
+    ipoApi: ProcosysIPOApiService;
 };
 
 export enum AsyncStatus {
@@ -35,6 +37,7 @@ type McAppContextProviderProps = {
     api: ProcosysApiService;
     appConfig: AppConfig;
     featureFlags: FeatureFlags;
+    ipoApi: ProcosysIPOApiService;
 };
 
 export const McAppContextProvider: React.FC<McAppContextProviderProps> = ({
@@ -43,6 +46,7 @@ export const McAppContextProvider: React.FC<McAppContextProviderProps> = ({
     api,
     appConfig,
     featureFlags,
+    ipoApi,
 }: McAppContextProviderProps) => {
     const [availablePlants, setAvailablePlants] = useState<Plant[]>([]);
     const [fetchPlantsStatus, setFetchPlantsStatus] = useState<AsyncStatus>(
@@ -61,6 +65,16 @@ export const McAppContextProvider: React.FC<McAppContextProviderProps> = ({
             }
         })();
     }, [api]);
+
+    useEffect(() => {
+        (async (): Promise<void> => {
+            try {
+                const isAlive = await ipoApi.isAlive();
+            } catch (error) {
+                console.log(error);
+            }
+        })();
+    }, [ipoApi]);
 
     if (fetchPlantsStatus === AsyncStatus.LOADING) {
         return <LoadingPage loadingText={'Loading available plants'} />;
@@ -90,6 +104,7 @@ export const McAppContextProvider: React.FC<McAppContextProviderProps> = ({
                 auth,
                 appConfig,
                 featureFlags,
+                ipoApi,
             }}
         >
             {children}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,8 @@ import {
     ReloadButton,
     LoadingPage,
 } from '@equinor/procosys-webapp-components';
+import procosysIPOApiService from './services/procosysIPOApi';
+import baseIPOApiService from './services/baseIPOApi';
 
 const render = (content: JSX.Element): void => {
     ReactDOM.render(
@@ -62,6 +64,17 @@ const initialize = async () => {
         axios: baseApiInstance,
         apiVersion: appConfig.procosysWebApi.apiVersion,
     });
+
+    const baseIpoApiInstance = baseIPOApiService({
+        authInstance,
+        baseURL: appConfig.ipoApi.baseUrl,
+        scope: appConfig.ipoApi.scope,
+    });
+
+    const procosysIPOApiInstance = procosysIPOApiService({
+        axios: baseIpoApiInstance,
+    });
+
     const { appInsightsReactPlugin } = initializeAppInsights(
         appConfig.appInsights.instrumentationKey
     );
@@ -71,6 +84,7 @@ const initialize = async () => {
         appInsightsReactPlugin,
         appConfig,
         featureFlags,
+        procosysIPOApiInstance,
     };
 };
 
@@ -83,6 +97,7 @@ const initialize = async () => {
             appInsightsReactPlugin,
             appConfig,
             featureFlags,
+            procosysIPOApiInstance,
         } = await initialize();
         render(
             <App
@@ -91,6 +106,7 @@ const initialize = async () => {
                 appInsightsReactPlugin={appInsightsReactPlugin}
                 appConfig={appConfig}
                 featureFlags={featureFlags}
+                procosysIPOApiInstance={procosysIPOApiInstance}
             />
         );
     } catch (error) {

--- a/src/services/appConfiguration.ts
+++ b/src/services/appConfiguration.ts
@@ -35,6 +35,7 @@ export type AppConfig = {
     procosysWebApi: ProcosysApiSettings;
     appInsights: AppInsightsConfig;
     ocrFunctionEndpoint: string;
+    ipoApi: ProcosysApiSettings;
 };
 
 type AppConfigResponse = {

--- a/src/services/baseIPOApi.ts
+++ b/src/services/baseIPOApi.ts
@@ -1,6 +1,5 @@
 import { StorageKey } from '@equinor/procosys-webapp-components';
 import axios, { AxiosInstance } from 'axios';
-import objectToCamelCase from '../utils/objectToCamelCase';
 import { IAuthService } from './authService';
 
 type baseIPOApiProps = {
@@ -33,12 +32,6 @@ const baseIPOApiService = ({
     });
     axiosInstance.interceptors.response.use(
         (response) => {
-            if (
-                typeof response.data === 'object' &&
-                !(response.data instanceof Blob)
-            ) {
-                response.data = objectToCamelCase(response.data);
-            }
             return response;
         },
         (error) => {

--- a/src/services/baseIPOApi.ts
+++ b/src/services/baseIPOApi.ts
@@ -1,0 +1,58 @@
+import { StorageKey } from '@equinor/procosys-webapp-components';
+import axios, { AxiosInstance } from 'axios';
+import objectToCamelCase from '../utils/objectToCamelCase';
+import { IAuthService } from './authService';
+
+type baseIPOApiProps = {
+    authInstance: IAuthService;
+    baseURL: string;
+    scope: string[];
+};
+
+const baseIPOApiService = ({
+    authInstance,
+    baseURL,
+    scope,
+}: baseIPOApiProps): AxiosInstance => {
+    const plantInStorage = window.localStorage.getItem(StorageKey.PLANT);
+    const axiosInstance = axios.create();
+    axiosInstance.defaults.baseURL = baseURL;
+    axiosInstance.interceptors.request.use(async (request) => {
+        try {
+            const token = await authInstance.getAccessToken(scope);
+            if (request.headers) {
+                request.headers['Authorization'] = `Bearer ${token}`;
+                if (plantInStorage !== 'undefined')
+                    request.headers['x-plant'] = `PCS$${plantInStorage}`;
+            }
+            return request;
+        } catch (error) {
+            const pcsError = error as Error;
+            throw new Error(pcsError.message);
+        }
+    });
+    axiosInstance.interceptors.response.use(
+        (response) => {
+            if (
+                typeof response.data === 'object' &&
+                !(response.data instanceof Blob)
+            ) {
+                response.data = objectToCamelCase(response.data);
+            }
+            return response;
+        },
+        (error) => {
+            if (axios.isCancel(error)) {
+                throw error;
+            }
+            if (error.response) {
+                throw new Error(error.response.data);
+            } else {
+                throw new Error(error.message);
+            }
+        }
+    );
+    return axiosInstance;
+};
+
+export default baseIPOApiService;

--- a/src/services/procosysIPOApi.ts
+++ b/src/services/procosysIPOApi.ts
@@ -1,0 +1,21 @@
+import { AxiosInstance } from 'axios';
+
+type ProcosysIPOApiServiceProps = {
+    axios: AxiosInstance;
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const procosysIPOApiService = ({ axios }: ProcosysIPOApiServiceProps) => {
+    const isAlive = async (): Promise<any[]> => {
+        const { data } = await axios.get(`Heartbeat/IsAlive`);
+        return data;
+    };
+
+    return {
+        isAlive,
+    };
+};
+
+export type ProcosysIPOApiService = ReturnType<typeof procosysIPOApiService>;
+
+export default procosysIPOApiService;

--- a/src/test/contexts.tsx
+++ b/src/test/contexts.tsx
@@ -17,6 +17,8 @@ import {
     FeatureFlags,
     ProcosysApiSettings,
 } from '../services/appConfiguration';
+import baseIPOApiService from '../services/baseIPOApi';
+import procosysIPOApiService, { ProcosysIPOApiService } from '../services/procosysIPOApi';
 
 const client = new Msal.PublicClientApplication({
     auth: { clientId: 'testId', authority: 'testAuthority' },
@@ -32,6 +34,11 @@ const dummyAppConfig: AppConfig = {
         instrumentationKey: '',
     },
     ocrFunctionEndpoint: 'https://dummy-org-endpoint.com',
+    ipoApi: {
+        baseUrl: 'testUrl',
+        apiVersion: '',
+        scope: ['']
+    }
 };
 
 const dummyFeatureFlags: FeatureFlags = {
@@ -49,12 +56,23 @@ const procosysApiInstance = procosysApiService({
     apiVersion: 'dummy-version',
 });
 
+const baseIPOApiInstance = baseIPOApiService({
+    authInstance,
+    baseURL: baseURL,
+    scope: ['testscope']
+});
+
+const ipoApiInstance = procosysIPOApiService({
+    axios: baseIPOApiInstance
+});
+
 type WithMcAppContextProps = {
     Component: JSX.Element;
     asyncStatus?: AsyncStatus;
     plants?: Plant[];
     auth?: IAuthService;
     api?: ProcosysApiService;
+    ipoApi?: ProcosysIPOApiService;
 };
 
 export const withMcAppContext = ({
@@ -63,6 +81,7 @@ export const withMcAppContext = ({
     plants = testPlants,
     auth = authInstance,
     api = procosysApiInstance,
+    ipoApi = ipoApiInstance,
 }: WithMcAppContextProps): JSX.Element => {
     return (
         <MemoryRouter initialEntries={['/test/sub/directory']}>
@@ -74,6 +93,7 @@ export const withMcAppContext = ({
                     api: api,
                     appConfig: dummyAppConfig,
                     featureFlags: dummyFeatureFlags,
+                    ipoApi: ipoApi
                 }}
             >
                 {Component}

--- a/src/test/dummyData.ts
+++ b/src/test/dummyData.ts
@@ -657,3 +657,9 @@ export const dummyTagResponse = {
         },
     ],
 };
+
+export const dummyIPOIsAliveResponse = {
+    isAlive: true,
+    timeStamp:'2022-08-09 13:11:18 UTC'
+};
+

--- a/src/test/setupServer.ts
+++ b/src/test/setupServer.ts
@@ -24,6 +24,7 @@ import {
     testSavedSearch,
     testChecklistSavedSearch,
     testPunchListItemSavedSearch,
+    dummyIPOIsAliveResponse,
 } from './dummyData';
 import objectToCamelCase from '../utils/objectToCamelCase';
 
@@ -96,6 +97,9 @@ export const ENDPOINTS = {
     //Work Order Attachments
     getWorkOrderAttachments: `${baseURL}/WorkOrder/Attachments`,
     getWorkOrderAttachment: `${baseURL}/WorkOrder/Attachment`,
+
+    //IPO
+    isAlive: `${baseURL}/IsAlive`,
 };
 
 export const server = setupServer(
@@ -322,6 +326,11 @@ export const server = setupServer(
             context.json(dummyAttachmentsResponse),
             context.status(200)
         );
+    }),
+
+    //IPO
+    rest.get(ENDPOINTS.isAlive, (_, response, context) => {
+        return response(context.json(dummyIPOIsAliveResponse), context.status(200));
     })
 );
 

--- a/src/utils/useCommonHooks.tsx
+++ b/src/utils/useCommonHooks.tsx
@@ -18,6 +18,7 @@ const useCommonHooks = () => {
         path,
         appConfig,
         procosysApiSettings: appConfig.procosysWebApi,
+        ipoApiSettings: appConfig.ipoApi,
     };
 };
 


### PR DESCRIPTION
Added support for IPO-API communication. 
Extended application configuration and added new services for calling IPO-api. 
Included a request on page load to isAlive method of Api (in McAppContext.tsx). This is the only method implemented in procosysIPOApiService for now.

New entry - ipoApi - added to Azure Config for all instances (dev, test, prod) so all is set to go. Also added respective clients to IPO Api instances in AD

[AB#93398](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/93398)