### PR TITLE
Feature/103964 improve search navigation in mc app

### DIFF
--- a/src/ConfirmSync.tsx
+++ b/src/ConfirmSync.tsx
@@ -6,7 +6,6 @@ import {
 } from '@equinor/procosys-webapp-components';
 import React from 'react';
 import styled from 'styled-components';
-import { LocalStorage } from './contexts/McAppContext';
 import { updateOfflineStatus } from './offline/OfflineStatus';
 import { OfflineStatus } from './typings/enums';
 import { db } from './offline/db';
@@ -17,9 +16,7 @@ const ContentWrapper = styled.main`
         margin-bottom: 16px;
     }
 `;
-const Spacer = styled.div`
-    height: 16px;
-`;
+
 const ButtonsWrapper = styled.div`
     display: flex;
     justify-content: space-between;

--- a/src/OfflinePin.tsx
+++ b/src/OfflinePin.tsx
@@ -2,10 +2,9 @@ import { Button, Input, Label } from '@equinor/eds-core-react';
 import { Navbar, ProcosysButton } from '@equinor/procosys-webapp-components';
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { LocalStorage } from './contexts/McAppContext';
 import { db } from './offline/db';
 import { updateOfflineStatus } from './offline/OfflineStatus';
-import { OfflineStatus } from './typings/enums';
+import { LocalStorage, OfflineStatus } from './typings/enums';
 
 const ContentWrapper = styled.main`
     margin: 16px;

--- a/src/components/AsyncPage.tsx
+++ b/src/components/AsyncPage.tsx
@@ -1,9 +1,11 @@
 import { Banner } from '@equinor/eds-core-react';
 import React from 'react';
-import { AsyncStatus } from '../contexts/McAppContext';
 import { COLORS } from '../style/GlobalStyles';
 import EdsIcon from './icons/EdsIcon';
-import { SkeletonLoadingPage } from '@equinor/procosys-webapp-components';
+import {
+    AsyncStatus,
+    SkeletonLoadingPage,
+} from '@equinor/procosys-webapp-components';
 
 type AsyncPageProps = {
     fetchStatus: AsyncStatus;

--- a/src/components/OutstandingIpos.tsx
+++ b/src/components/OutstandingIpos.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import Axios from 'axios';
 import {
+    AsyncStatus,
     CollapsibleCard,
     SkeletonLoadingPage,
 } from '@equinor/procosys-webapp-components';
 import styled from 'styled-components';
 import useCommonHooks from '../utils/useCommonHooks';
-import { AsyncStatus } from '../contexts/McAppContext';
 import { OutstandingIposType } from '../services/apiTypes';
 import OutstandingIpoResult from './OutstandingIpoResult';
 

--- a/src/components/TagInfoWrapper.tsx
+++ b/src/components/TagInfoWrapper.tsx
@@ -1,7 +1,6 @@
-import { TagInfo } from '@equinor/procosys-webapp-components';
+import { AsyncStatus, TagInfo } from '@equinor/procosys-webapp-components';
 import React, { useState } from 'react';
 import { useEffect } from 'react';
-import { AsyncStatus } from '../contexts/McAppContext';
 import { AdditionalTagField, TagDetails } from '../services/apiTypes';
 import useCommonHooks from '../utils/useCommonHooks';
 

--- a/src/components/navigation/SideMenu.tsx
+++ b/src/components/navigation/SideMenu.tsx
@@ -6,9 +6,8 @@ import PlantContext from '../../contexts/PlantContext';
 import useCommonHooks from '../../utils/useCommonHooks';
 import { COLORS } from '../../style/GlobalStyles';
 import { isOfType, StorageKey } from '@equinor/procosys-webapp-components';
-import { OfflineStatus } from '../../typings/enums';
+import { LocalStorage, OfflineStatus } from '../../typings/enums';
 import packageJson from '../../../package.json';
-import { LocalStorage } from '../../contexts/McAppContext';
 
 const SideMenuWrapper = styled.aside<{ isActive: boolean }>`
     width: 297px;

--- a/src/contexts/McAppContext.tsx
+++ b/src/contexts/McAppContext.tsx
@@ -4,6 +4,7 @@ import {
     ErrorPage,
     ReloadButton,
     LoadingPage,
+    AsyncStatus,
 } from '@equinor/procosys-webapp-components';
 import { Plant } from '../services/apiTypes';
 import { AppConfig, FeatureFlags } from '../services/appConfiguration';
@@ -25,22 +26,6 @@ type McAppContextProps = {
     configurationAccessToken: string;
     ipoApi: ProcosysIPOApiService;
 };
-
-export enum AsyncStatus {
-    INACTIVE,
-    LOADING,
-    SUCCESS,
-    ERROR,
-    EMPTY_RESPONSE,
-}
-
-export enum LocalStorage {
-    LOGIN_TRIES = 'loginTries',
-    OFFLINE_PROJECT_ID = 'offlineProjectId',
-    OFFLINE_STATUS = 'offlineStatus',
-    SYNCH_ERRORS = 'SynchErrors',
-    SW_UPDATE = 'serviceWorkerUpdate',
-}
 
 const McAppContext = React.createContext({} as McAppContextProps);
 

--- a/src/contexts/PlantContext.tsx
+++ b/src/contexts/PlantContext.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useContext, useEffect, useState } from 'react';
 import { Plant, Project } from '../services/apiTypes';
 import matchPlantInURL from '../utils/matchPlantInURL';
 import matchProjectInURL from '../utils/matchProjectInURL';
-import McAppContext, { AsyncStatus } from './McAppContext';
+import McAppContext from './McAppContext';
 import useCommonHooks from '../utils/useCommonHooks';
 import { Button } from '@equinor/eds-core-react';
 import {
@@ -12,6 +12,7 @@ import {
     ProcosysButton,
     ReloadButton,
     StorageKey,
+    AsyncStatus,
 } from '@equinor/procosys-webapp-components';
 import { OfflineStatus } from '../typings/enums';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,9 +23,12 @@ import {
     updateOfflineStatus,
 } from './offline/OfflineStatus';
 import { syncronizeOfflineUpdatesWithBackend } from './offline/syncUpdatesWithBackend';
-import { OfflineScopeStatus, OfflineStatus } from './typings/enums';
+import {
+    LocalStorage,
+    OfflineScopeStatus,
+    OfflineStatus,
+} from './typings/enums';
 import hasConnectionToServer from './utils/hasConnectionToServer';
-import { LocalStorage } from './contexts/McAppContext';
 import ConfirmSync from './ConfirmSync';
 
 const onUpdate = (registration: ServiceWorkerRegistration): void => {

--- a/src/offline/OfflineStatus.ts
+++ b/src/offline/OfflineStatus.ts
@@ -1,6 +1,5 @@
 import { isOfType } from '@equinor/procosys-webapp-components';
-import { LocalStorage } from '../contexts/McAppContext';
-import { OfflineStatus } from '../typings/enums';
+import { LocalStorage, OfflineStatus } from '../typings/enums';
 
 export const getOfflineStatusfromLocalStorage = (): OfflineStatus => {
     const offlineStatus = localStorage.getItem(LocalStorage.OFFLINE_STATUS);

--- a/src/offline/syncUpdatesWithBackend.ts
+++ b/src/offline/syncUpdatesWithBackend.ts
@@ -1,5 +1,5 @@
 import { ProcosysApiService } from '../services/procosysApi';
-import { EntityType, OfflineStatus } from '../typings/enums';
+import { EntityType, LocalStorage, OfflineStatus } from '../typings/enums';
 import { OfflineUpdateRepository } from './OfflineUpdateRepository';
 import {
     OfflineUpdateRequest,
@@ -11,7 +11,6 @@ import { OfflineSynchronizationErrors } from '../services/apiTypes';
 import { getOfflineProjectIdfromLocalStorage } from './OfflineStatus';
 import { HTTPError, StorageKey } from '@equinor/procosys-webapp-components';
 import { db } from './db';
-import { LocalStorage } from '../contexts/McAppContext';
 
 const offlineUpdateRepository = new OfflineUpdateRepository();
 

--- a/src/pages/Checklist/ChecklistDetailsCard.tsx
+++ b/src/pages/Checklist/ChecklistDetailsCard.tsx
@@ -1,7 +1,6 @@
 import { DotProgress } from '@equinor/eds-core-react';
-import { InfoItem } from '@equinor/procosys-webapp-components';
+import { AsyncStatus, InfoItem } from '@equinor/procosys-webapp-components';
 import React from 'react';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import { ChecklistResponse } from '../../services/apiTypes';
 import { DetailsWrapper } from '../Entity/EntityPageDetailsCard';
 

--- a/src/pages/Checklist/ChecklistPage.tsx
+++ b/src/pages/Checklist/ChecklistPage.tsx
@@ -5,11 +5,11 @@ import useCommonHooks from '../../utils/useCommonHooks';
 import { Route, Switch } from 'react-router-dom';
 import ChecklistWrapper from './ChecklistWrapper';
 import NewPunchWrapper from './NewPunchWrapper';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import { ChecklistResponse, PunchPreview } from '../../services/apiTypes';
 import { Button } from '@equinor/eds-core-react';
 import TagInfoWrapper from '../../components/TagInfoWrapper';
 import {
+    AsyncStatus,
     BackButton,
     FooterButton,
     Navbar,

--- a/src/pages/Checklist/NewPunchWrapper.tsx
+++ b/src/pages/Checklist/NewPunchWrapper.tsx
@@ -6,10 +6,10 @@ import {
     PunchSort,
     PunchType,
 } from '../../services/apiTypes';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import { NewPunch as NewPunchType } from '../../services/apiTypes';
 import useCommonHooks from '../../utils/useCommonHooks';
 import {
+    AsyncStatus,
     ChosenPerson,
     NewPunch,
     removeSubdirectories,

--- a/src/pages/Entity/EntityPage.tsx
+++ b/src/pages/Entity/EntityPage.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import styled from 'styled-components';
 import useCommonHooks from '../../utils/useCommonHooks';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import {
     ChecklistPreview,
     PunchPreview,
@@ -17,6 +16,7 @@ import EdsIcon from '../../components/icons/EdsIcon';
 import { COLORS } from '../../style/GlobalStyles';
 import WorkOrderInfo from './WorkOrderInfo';
 import {
+    AsyncStatus,
     BackButton,
     FooterButton,
     Navbar,

--- a/src/pages/Entity/EntityPageDetailsCard.tsx
+++ b/src/pages/Entity/EntityPageDetailsCard.tsx
@@ -1,5 +1,6 @@
 import { DotProgress } from '@equinor/eds-core-react';
 import {
+    AsyncStatus,
     EntityDetails,
     isOfType,
     SearchType,
@@ -8,7 +9,6 @@ import {
 import React from 'react';
 import styled from 'styled-components';
 import McDetails from '../../components/detailCards/McDetails';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import {
     IpoDetails,
     McPkgPreview,

--- a/src/pages/Entity/WorkOrderInfo.tsx
+++ b/src/pages/Entity/WorkOrderInfo.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { Button } from '@equinor/eds-core-react';
 import {
+    AsyncStatus,
     Attachments,
     CollapsibleCard,
     ErrorPage,
@@ -9,7 +10,6 @@ import {
 } from '@equinor/procosys-webapp-components';
 import styled from 'styled-components';
 import AsyncPage from '../../components/AsyncPage';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import { isOfType } from '../../services/apiTypeGuards';
 import {
     Attachment,

--- a/src/pages/Punch/ClearPunchWrapper.tsx
+++ b/src/pages/Punch/ClearPunchWrapper.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import useCommonHooks from '../../utils/useCommonHooks';
 import {
     PunchCategory,
@@ -15,6 +14,7 @@ import {
     UpdatePunchData,
     useSnackbar,
     PunchAction,
+    AsyncStatus,
 } from '@equinor/procosys-webapp-components';
 import usePersonsSearchFacade from '../../utils/usePersonsSearchFacade';
 import { OfflineStatus } from '../../typings/enums';

--- a/src/pages/Punch/PunchPage.tsx
+++ b/src/pages/Punch/PunchPage.tsx
@@ -6,7 +6,6 @@ import { COLORS } from '../../style/GlobalStyles';
 import useCommonHooks from '../../utils/useCommonHooks';
 import ClearPunchWrapper from './ClearPunchWrapper';
 import { PunchItem } from '../../services/apiTypes';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import VerifyPunchWrapper from './VerifyPunchWrapper';
 import {
     SkeletonLoadingPage,
@@ -17,6 +16,7 @@ import {
     FooterButton,
     removeSubdirectories,
     useSnackbar,
+    AsyncStatus,
 } from '@equinor/procosys-webapp-components';
 import { DotProgress } from '@equinor/eds-core-react';
 import AsyncPage from '../../components/AsyncPage';

--- a/src/pages/Punch/VerifyPunchWrapper.tsx
+++ b/src/pages/Punch/VerifyPunchWrapper.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import { PunchItem } from '../../services/apiTypes';
 import useCommonHooks from '../../utils/useCommonHooks';
 import {
@@ -7,6 +6,7 @@ import {
     useSnackbar,
     VerifyPunch,
     PunchAction,
+    AsyncStatus,
 } from '@equinor/procosys-webapp-components';
 
 type VerifyPunchProps = {

--- a/src/pages/SavedSearch/SavedSearchPage.tsx
+++ b/src/pages/SavedSearch/SavedSearchPage.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import {
     ChecklistSavedSearchResult,
     PunchItemSavedSearchResult,
@@ -9,6 +8,7 @@ import useCommonHooks from '../../utils/useCommonHooks';
 import AsyncPage from '../../components/AsyncPage';
 import { isArrayOfType } from '../../services/apiTypeGuards';
 import {
+    AsyncStatus,
     BackButton,
     InfoItem,
     Navbar,

--- a/src/pages/Search/SavedSearches/SavedSearchResult.tsx
+++ b/src/pages/Search/SavedSearches/SavedSearchResult.tsx
@@ -2,10 +2,10 @@ import { Button } from '@equinor/eds-core-react';
 import React from 'react';
 import styled from 'styled-components';
 import EdsIcon from '../../../components/icons/EdsIcon';
-import { AsyncStatus } from '../../../contexts/McAppContext';
 import { SavedSearch, ApiSavedSearchType } from '../../../services/apiTypes';
 import { Caption, COLORS } from '../../../style/GlobalStyles';
 import useCommonHooks from '../../../utils/useCommonHooks';
+import { AsyncStatus } from '@equinor/procosys-webapp-components';
 
 const SavedSearchWrapper = styled.article`
     cursor: pointer;

--- a/src/pages/Search/SavedSearches/SavedSearches.tsx
+++ b/src/pages/Search/SavedSearches/SavedSearches.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { AsyncStatus } from '../../../contexts/McAppContext';
 import { SavedSearch } from '../../../services/apiTypes';
 import useCommonHooks from '../../../utils/useCommonHooks';
 import {
+    AsyncStatus,
     CollapsibleCard,
     SkeletonLoadingPage,
 } from '@equinor/procosys-webapp-components';

--- a/src/pages/Search/Search.tsx
+++ b/src/pages/Search/Search.tsx
@@ -2,13 +2,14 @@ import React, { useState } from 'react';
 import SavedSearches from './SavedSearches/SavedSearches';
 import SearchArea from './Searching/SearchArea';
 import styled from 'styled-components';
-import { OfflineStatus } from '../../typings/enums';
+import { OfflineStatus, SessionStorage } from '../../typings/enums';
 import useCommonHooks from '../../utils/useCommonHooks';
 import OutstandingIpos from '../../components/OutstandingIpos';
 import {
     SearchType,
     SearchTypeButton,
 } from '@equinor/procosys-webapp-components';
+import { unfold_less } from '@equinor/eds-icons';
 
 const ButtonsWrapper = styled.div`
     display: flex;
@@ -23,7 +24,9 @@ interface SearchProps {
 }
 
 const Search = ({ setSnackbarText }: SearchProps): JSX.Element => {
-    const [searchType, setSearchType] = useState<string>();
+    const [searchType, setSearchType] = useState<string | undefined>(
+        sessionStorage.getItem(SessionStorage.SEARCH_TYPE) ?? undefined
+    );
     const { offlineState } = useCommonHooks();
 
     const determineComponent = (): JSX.Element => {

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -16,10 +16,9 @@ import EdsIcon from '../../components/icons/EdsIcon';
 import { Route, Switch } from 'react-router-dom';
 import Bookmarks from './Bookmarks/Bookmarks';
 import Search from './Search';
-import { OfflineStatus } from '../../typings/enums';
+import { LocalStorage, OfflineStatus } from '../../typings/enums';
 import SyncErrors from './SyncErrors';
 import { OfflineSynchronizationErrors } from '../../services/apiTypes';
-import { LocalStorage } from '../../contexts/McAppContext';
 
 const SearchPageWrapper = styled.main`
     padding: 0;

--- a/src/pages/Search/SyncErrors.tsx
+++ b/src/pages/Search/SyncErrors.tsx
@@ -9,7 +9,6 @@ import {
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import EdsIcon from '../../components/icons/EdsIcon';
-import { LocalStorage } from '../../contexts/McAppContext';
 import { db } from '../../offline/db';
 import {
     getOfflineProjectIdfromLocalStorage,
@@ -17,7 +16,11 @@ import {
 } from '../../offline/OfflineStatus';
 import { OfflineSynchronizationErrors } from '../../services/apiTypes';
 import { COLORS } from '../../style/GlobalStyles';
-import { OfflineScopeStatus, OfflineStatus } from '../../typings/enums';
+import {
+    LocalStorage,
+    OfflineScopeStatus,
+    OfflineStatus,
+} from '../../typings/enums';
 import useCommonHooks from '../../utils/useCommonHooks';
 import { ButtonsWrapper } from './Bookmarks/Bookmarks';
 import { BookmarksPopup } from './Bookmarks/BookmarksPopups';

--- a/src/pages/Search/useSearchPageFacade.tsx
+++ b/src/pages/Search/useSearchPageFacade.tsx
@@ -5,6 +5,7 @@ import { ProcosysApiService } from '../../services/procosysApi';
 import useCommonHooks from '../../utils/useCommonHooks';
 import { SearchType } from '@equinor/procosys-webapp-components';
 import { ProcosysIPOApiService } from '../../services/procosysIPOApi';
+import { SessionStorage } from '../../typings/enums';
 
 export enum SearchStatus {
     INACTIVE,
@@ -65,6 +66,9 @@ const fetchHits = async (
 ): Promise<void> => {
     dispatch({ type: 'FETCH_START' });
     try {
+        sessionStorage.setItem(SessionStorage.SEARCH_TYPE, searchType);
+        sessionStorage.setItem(SessionStorage.SEARCH_QUERY, query);
+        sessionStorage.setItem(SessionStorage.SECONDARY_QUERY, secondaryQuery);
         if (searchType === SearchType.IPO) {
             const results = await ipoApi.getIpoOnSearch(
                 plantId,

--- a/src/pages/Search/useSearchPageFacade.tsx
+++ b/src/pages/Search/useSearchPageFacade.tsx
@@ -106,13 +106,22 @@ const useSearchPageFacade = (searchType: string) => {
         hits: { maxAvailable: 0, items: [] },
         searchStatus: SearchStatus.INACTIVE,
     });
-    const [query, setQuery] = useState('');
-    const [secondaryQuery, setSecondaryQuery] = useState('');
+    const [query, setQuery] = useState(
+        sessionStorage.getItem(SessionStorage.SEARCH_QUERY) ?? ''
+    );
+    const [secondaryQuery, setSecondaryQuery] = useState(
+        sessionStorage.getItem(SessionStorage.SECONDARY_QUERY) ?? ''
+    );
     const { currentProject, currentPlant } = useContext(PlantContext);
+    const [firstRender, setFirstRender] = useState<boolean>(true);
 
     useEffect(() => {
-        setSecondaryQuery('');
-        setQuery('');
+        if (firstRender) {
+            setFirstRender(false);
+        } else {
+            setSecondaryQuery('');
+            setQuery('');
+        }
     }, [searchType]);
 
     useEffect(() => {

--- a/src/pages/SelectPlant/SelectPlant.test.tsx
+++ b/src/pages/SelectPlant/SelectPlant.test.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import { withMcAppContext } from '../../test/contexts';
 import { testPlants } from '../../test/dummyData';
 import { OfflineStatus } from '../../typings/enums';
 import SelectPlant from './SelectPlant';
+import { AsyncStatus } from '@equinor/procosys-webapp-components';
 
 describe('<SelectPlant />', () => {
     it('Renders plant buttons successfully upon loading', () => {

--- a/src/pages/SelectProject/SelectProject.test.tsx
+++ b/src/pages/SelectProject/SelectProject.test.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { AsyncStatus } from '../../contexts/McAppContext';
 import { withPlantContext } from '../../test/contexts';
 import { testProjects } from '../../test/dummyData';
 import { OfflineStatus } from '../../typings/enums';
 import SelectProject from '../SelectProject/SelectProject';
+import { AsyncStatus } from '@equinor/procosys-webapp-components';
 
 describe('<SelectProject />', () => {
     it('Renders project buttons successfully upon loading', () => {

--- a/src/services/withAccessControl.tsx
+++ b/src/services/withAccessControl.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useContext, ReactElement } from 'react';
 import PlantContext from '../contexts/PlantContext';
-import McAppContext, { AsyncStatus } from '../contexts/McAppContext';
+import McAppContext from '../contexts/McAppContext';
 import { Button } from '@equinor/eds-core-react';
 import useCommonHooks from '../utils/useCommonHooks';
 import {
+    AsyncStatus,
     ErrorPage,
     HomeButton,
     SkeletonLoadingPage,

--- a/src/test/contexts.tsx
+++ b/src/test/contexts.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import PlantContext from '../contexts/PlantContext';
-import McAppContext, { AsyncStatus } from '../contexts/McAppContext';
+import McAppContext from '../contexts/McAppContext';
 import * as Msal from '@azure/msal-browser';
 import { Plant, Project } from '../services/apiTypes';
 import procosysApiService, {
@@ -16,6 +16,7 @@ import procosysIPOApiService, {
     ProcosysIPOApiService,
 } from '../services/procosysIPOApi';
 import { OfflineStatus } from '../typings/enums';
+import { AsyncStatus } from '@equinor/procosys-webapp-components';
 
 const client = new Msal.PublicClientApplication({
     auth: { clientId: 'testId', authority: 'testAuthority' },

--- a/src/typings/enums.ts
+++ b/src/typings/enums.ts
@@ -87,4 +87,5 @@ export enum LocalStorage {
 export enum SessionStorage {
     SEARCH_TYPE = 'searchType',
     SEARCH_QUERY = 'searchQuery',
+    SECONDARY_QUERY = 'secondaryQuery',
 }

--- a/src/typings/enums.ts
+++ b/src/typings/enums.ts
@@ -83,3 +83,8 @@ export enum LocalStorage {
     SYNCH_ERRORS = 'SynchErrors',
     SW_UPDATE = 'serviceWorkerUpdate',
 }
+
+export enum SessionStorage {
+    SEARCH_TYPE = 'searchType',
+    SEARCH_QUERY = 'searchQuery',
+}

--- a/src/typings/enums.ts
+++ b/src/typings/enums.ts
@@ -74,3 +74,12 @@ export enum IpoOrganizationsEnum {
     Supplier = 'Supplier',
     External = 'External',
 }
+
+// Browser stores
+export enum LocalStorage {
+    LOGIN_TRIES = 'loginTries',
+    OFFLINE_PROJECT_ID = 'offlineProjectId',
+    OFFLINE_STATUS = 'offlineStatus',
+    SYNCH_ERRORS = 'SynchErrors',
+    SW_UPDATE = 'serviceWorkerUpdate',
+}

--- a/src/utils/textFieldHelpers.tsx
+++ b/src/utils/textFieldHelpers.tsx
@@ -1,5 +1,5 @@
+import { AsyncStatus } from '@equinor/procosys-webapp-components';
 import React from 'react';
-import { AsyncStatus } from '../contexts/McAppContext';
 
 enum TextFieldVariants {
     ERROR = 'error',

--- a/src/utils/useAsyncGet.tsx
+++ b/src/utils/useAsyncGet.tsx
@@ -1,6 +1,6 @@
+import { AsyncStatus } from '@equinor/procosys-webapp-components';
 import Axios, { CancelToken } from 'axios';
 import { useEffect, useState } from 'react';
-import { AsyncStatus } from '../contexts/McAppContext';
 
 function useAsyncGet<T>(
     asyncFunction: (cancelToken: CancelToken) => Promise<T>

--- a/src/utils/useBookmarks.tsx
+++ b/src/utils/useBookmarks.tsx
@@ -7,6 +7,7 @@ import { useContext, useEffect, useState } from 'react';
 import PlantContext from '../contexts/PlantContext';
 import {
     EntityType,
+    LocalStorage,
     OfflineScopeStatus,
     OfflineStatus,
 } from '../typings/enums';
@@ -16,7 +17,6 @@ import buildOfflineScope from '../offline/buildOfflineScope';
 import { db } from '../offline/db';
 import { updateOfflineStatus } from '../offline/OfflineStatus';
 import { OfflineContentRepository } from '../offline/OfflineContentRepository';
-import { LocalStorage } from '../contexts/McAppContext';
 
 export enum OfflineAction {
     INACTIVE = 0,


### PR DESCRIPTION
[AB#103964](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/103964)
If a user has searched for somehing in the app and clicked on a search result he/she can click back and see what he/she searched for before clicking. Before the user would have to search again for the same thing