### PR TITLE
bug/108346-add-attachment/image-to-punchitem-fails-when-syncing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mc",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "homepage": "https://apps.procosys.com/mc",
   "private": true,
   "dependencies": {

--- a/src/offline/syncUpdatesWithBackend.ts
+++ b/src/offline/syncUpdatesWithBackend.ts
@@ -455,7 +455,7 @@ const updateIdOnEntityRequest = (
             offlineUpdate.entityId = newId;
             offlineUpdate.bodyData = newId.toString();
         } else if (offlineUpdate.url.startsWith('PunchListItem/Attachment?')) {
-            const oldId = temporaryId;
+            const { entityId: oldId } = offlineUpdate;
             if (oldId) {
                 offlineUpdate.url = offlineUpdate.url.replace(
                     oldId.toString(),


### PR DESCRIPTION
Changed oldId to use entityId from offlineUpdate, seems to be punchitemId

[AB#108346](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/108346)